### PR TITLE
Initial pass at speeling cleanup

### DIFF
--- a/advanced/gain-scheduling.md
+++ b/advanced/gain-scheduling.md
@@ -33,7 +33,7 @@ Let's say that this is our current code:&#x20;
 ```java
 // imaginary PID controller and coefficients objects 
 PIDCoefficients for90Degrees = new PIDCoefficients(); 
-PIDController controller = new PID(for90Dgrees);  
+PIDController controller = new PID(for90Degrees);  
 
 
 while (loopIsRunning) {

--- a/advanced/motion-profiling.md
+++ b/advanced/motion-profiling.md
@@ -14,7 +14,7 @@ Imagine that we're trying to move our robot along a 1D line to a certain referen
 
 The trivial method to limit acceleration is to cap the output of the PID Controller, but we can do better.
 
-What if we could directly choose a maximum acceleration? And a maximum deacceleration too? (slip also occurs when we deaccelerate too quickly!). What if we also wanted to specify a maximum velocity because we may know that some velocities are too high to control reasonably?
+What if we could directly choose a maximum acceleration? And a maximum deceleration too? (slip also occurs when we decelerate too quickly!). What if we also wanted to specify a maximum velocity because we may know that some velocities are too high to control reasonably?
 
 That's where motion profiling comes in!
 
@@ -30,7 +30,7 @@ The most common type of motion profile in FTC is the trapezoidal motion profile.
 
 <figure><img src="../.gitbook/assets/motion_profile.png" alt=""><figcaption></figcaption></figure>
 
-It consists of three phrases: acceleration, cruise, and deacceleration. In the first phase, the target velocity increases by the maximum acceleration, in the cruise phase the target velocity doesn't change, and the target velocity decreases by the maximum acceleration, ending at a target velocity of 0.
+It consists of three phrases: acceleration, cruise, and deceleration. In the first phase, the target velocity increases by the maximum acceleration, in the cruise phase the target velocity doesn't change, and the target velocity decreases by the maximum acceleration, ending at a target velocity of 0.
 
 Trapezoidal motion profiles are relatively simple, and they're going to be sufficient for smooth and precise motion for pretty much any type of mechanism in FTC.
 
@@ -62,15 +62,15 @@ double motion_profile(max_acceleration, max_velocity, distance, elapsed_time) {
   max_velocity = max_acceleration * acceleration_dt
 
   // we decelerate at the same rate as we accelerate
-  deacceleration_dt = acceleration_dt
+  deceleration_dt = acceleration_dt
 
   // calculate the time that we're at max velocity
   cruise_distance = distance - 2 * acceleration_distance
   cruise_dt = cruise_distance / max_velocity
-  deacceleration_time = acceleration_dt + cruise_dt
+  deceleration_time = acceleration_dt + cruise_dt
 
   // check if we're still in the motion profile
-  entire_dt = acceleration_dt + cruise_dt + deacceleration_dt
+  entire_dt = acceleration_dt + cruise_dt + deceleration_dt
   if (elapsed_time > entire_dt)
     return distance
 
@@ -80,7 +80,7 @@ double motion_profile(max_acceleration, max_velocity, distance, elapsed_time) {
     return 0.5 * max_acceleration * elapsed_time ** 2
 
   // if we're cruising
-  else if (elapsed_time < deacceleration_time) {
+  else if (elapsed_time < deceleration_time) {
     acceleration_distance = 0.5 * max_acceleration * acceleration_dt ** 2
     cruise_current_dt = elapsed_time - acceleration_dt
 
@@ -92,10 +92,10 @@ double motion_profile(max_acceleration, max_velocity, distance, elapsed_time) {
   else {
     acceleration_distance = 0.5 * max_acceleration * acceleration_dt ** 2
     cruise_distance = max_velocity * cruise_dt
-    deacceleration_time = elapsed_time - deacceleration_time
+    deceleration_time = elapsed_time - deceleration_time
 
     // use the kinematic equations to calculate the instantaneous desired position
-    return acceleration_distance + cruise_distance + max_velocity * deacceleration_time - 0.5 * max_acceleration * deacceleration_time ** 2
+    return acceleration_distance + cruise_distance + max_velocity * deceleration_time - 0.5 * max_acceleration * deceleration_time ** 2
   }
 }
 ```

--- a/feedforward-control.md
+++ b/feedforward-control.md
@@ -18,7 +18,7 @@ Another great use for feedforward is to replace the integral term of a feedback 
 double output = K * reference;
 ```
 
-As you can see, feedforward is farily trivial compared to the feedback control loops such as PID that we implemented in previous chapters. This is because feedforward is acting almost as a unit conversion between some input and some output. This conversion is determined by the tuned value K in the code snippet above.
+As you can see, feedforward is fairly trivial compared to the feedback control loops such as PID that we implemented in previous chapters. This is because feedforward is acting almost as a unit conversion between some input and some output. This conversion is determined by the tuned value K in the code snippet above.
 
 In FTC this value is often referred to as 'Kv', specifically when dealing with controlling the velocity of a plant. Additionally a term for acceleration, fittingly called 'Ka' can also be added.
 

--- a/homeostasis-by-thermal-equilibrium/included-controllers.md
+++ b/homeostasis-by-thermal-equilibrium/included-controllers.md
@@ -84,7 +84,7 @@ while (true) {
 }
 ```
 
-This controller takes in two parameters, it's output power and a tolerance.  This controller works by making a simple comparison: is it too low or is it too high and then applies either maxOutput or -maxOutput to the system.  If the error is within tolerance (or hysterisis as the parameter is called), then the controller will return 0. This hysterisis prevents the bang bang controller from oscillating forever but has the trade off of introducing some state error.&#x20;
+This controller takes in two parameters, it's output power and a tolerance.  This controller works by making a simple comparison: is it too low or is it too high and then applies either maxOutput or -maxOutput to the system.  If the error is within tolerance (or hysteresis as the parameter is called), then the controller will return 0. This hysteresis prevents the bang bang controller from oscillating forever but has the trade off of introducing some state error.&#x20;
 
 ## Dealing with Angles
 

--- a/homeostasis-by-thermal-equilibrium/what-is-homeostasis.md
+++ b/homeostasis-by-thermal-equilibrium/what-is-homeostasis.md
@@ -18,8 +18,8 @@ Currently homestasis provides the following features:
 * Estimation algorithms to improve sensor readings:
   * Low Pass Filter
   * Least Squares + Kalman Filter
-* Many useful utilies such as the WPILib Motion Profile and functions to deal with angles.&#x20;
-* Systems to easily utilize the afformentioned algorithms in a unified way.
+* Many useful utilities such as the WPILib Motion Profile and functions to deal with angles.&#x20;
+* Systems to easily utilize the aforementioned algorithms in a unified way.
   * BasicSystem
     * A combination of an Estimator, Feedback, and Feedforward Controller
   * &#x20;PositionVelocitySystem

--- a/introduction-to-open-loop-control.md
+++ b/introduction-to-open-loop-control.md
@@ -38,22 +38,22 @@ These examples and nearly all further examples assume that you have correctly se
 
 ![Simulink Diagram of an Open Loop Motor controller](.gitbook/assets/screen-shot-2021-04-08-at-7.20.35-pm.png)
 
-As you can see, open loop control is an incredibly simple way to get your robot performing actions.  This method does unforunately have a few critical downfalls for certain systems.&#x20;
+As you can see, open loop control is an incredibly simple way to get your robot performing actions.  This method does unfortunately have a few critical downfalls for certain systems.&#x20;
 
 These downfalls consist of the following:
 
 * Cannot reject disturbances
   * Cannot overcome contact from other robots.  &#x20;
-* Energy ineffecient
+* Energy inefficient
   * Motors must run at maximum power to utilize all of their maximum torque potential&#x20;
 * Consistency will vary as battery voltage changes.    &#x20;
 
-These downfalls really only matter for certain types of systems.  For example, your intake doesnt really need to reject distrubances from the outside world like your drivetrain does.  This means that choosing Open Loop Control vs Closed Loop Control is decided with personal preference and the _**design requirements**_ of your system.
+These downfalls really only matter for certain types of systems.  For example, your intake doesn't really need to reject disturbances from the outside world like your drivetrain does.  This means that choosing Open Loop Control vs Closed Loop Control is decided with personal preference and the _**design requirements**_ of your system.
 
 {% hint style="info" %}
 **Design Requirements**: What your system needs to accomplish.
 
-Does it need to reject distrubances? Does it need to be fast? Can it be slow? How accurate does it need to be? All of these things  are factored into your systems **Design Requirements**.&#x20;
+Does it need to reject disturbances? Does it need to be fast? Can it be slow? How accurate does it need to be? All of these things  are factored into your systems **Design Requirements**.&#x20;
 {% endhint %}
 
 #### Practice Exercises

--- a/motion-profiling.md
+++ b/motion-profiling.md
@@ -10,7 +10,7 @@ Imagine that we're trying to move our robot along a 1D line to a certain referen
 
 What if we had some way to the acceleration so that slip wouldn't occur? Well, we could simply cap the output of the PID Controller and call it a day, and that would work pretty well. But we can do better.
 
-What if we could directly choose a maximum acceleration? And a maximum deacceleration too? (slip also occurs when we deacceleration too quickly!). What if we also wanted to specify a maximum velocity, because we may know that some velocities are too high for us to reasonably control?
+What if we could directly choose a maximum acceleration? And a maximum deceleration too? (slip also occurs when we deceleration too quickly!). What if we also wanted to specify a maximum velocity, because we may know that some velocities are too high for us to reasonably control?
 
 That's where motion profiling comes in!
 
@@ -26,7 +26,7 @@ The most common type of motion profile in FTC is the trapezoidal motion profile.
 
 ![Graph of a motion profile](.gitbook/assets/motion_profile.png)
 
-It consists of three phrases: acceleration, cruise, and deacceleration. In the first phase, the target velocity increases by the maximum acceleration, in the cruise phase the target velocity doesn't change, and the target velocity decreases by the maximum acceleration, ending at a target velocity of 0.
+It consists of three phrases: acceleration, cruise, and deceleration. In the first phase, the target velocity increases by the maximum acceleration, in the cruise phase the target velocity doesn't change, and the target velocity decreases by the maximum acceleration, ending at a target velocity of 0.
 
 Trapezoidal motion profiles are relatively simple, and they're going to be sufficient for smooth and precise motion for pretty much any type of mechanism in FTC.
 
@@ -59,15 +59,15 @@ double motion_profile(max_acceleration, max_velocity, distance, current_dt) {
   max_velocity = max_acceleration * acceleration_dt
 
   // we decelerate at the same rate as we accelerate
-  deacceleration_dt = acceleration_dt
+  deceleration_dt = acceleration_dt
 
   // calculate the time that we're at max velocity
   cruise_distance = distance - 2 * acceleration_distance
   cruise_dt = cruise_distance / max_velocity
-  deacceleration_time = acceleration_dt + cruise_dt
+  deceleration_time = acceleration_dt + cruise_dt
 
   // check if we're still in the motion profile
-  entire_dt = acceleration_dt + cruise_dt + deacceleration_dt
+  entire_dt = acceleration_dt + cruise_dt + deceleration_dt
   if (current_dt > entire_dt)
     return distance
 
@@ -77,7 +77,7 @@ double motion_profile(max_acceleration, max_velocity, distance, current_dt) {
     return 0.5 * max_acceleration * current_dt ** 2
 
   // if we're cruising
-  else if (current_dt < deacceleration_time) {
+  else if (current_dt < deceleration_time) {
     acceleration_distance = 0.5 * max_acceleration * acceleration_dt ** 2
     cruise_current_dt = current_dt - acceleration_dt
 
@@ -89,10 +89,10 @@ double motion_profile(max_acceleration, max_velocity, distance, current_dt) {
   else {
     acceleration_distance = 0.5 * max_acceleration * acceleration_dt ** 2
     cruise_distance = max_velocity * cruise_dt
-    deacceleration_time = current_dt - deacceleration_time
+    deceleration_time = current_dt - deceleration_time
 
     // use the kinematic equations to calculate the distance traveled while decelerating
-    return acceleration_distance + cruise_distance + max_velocity * deacceleration_time - 0.5 * max_acceleration * deacceleration_time ** 2
+    return acceleration_distance + cruise_distance + max_velocity * deceleration_time - 0.5 * max_acceleration * deceleration_time ** 2
   }
 }
 ```

--- a/the-pid-controller/practical-improvements-to-pid.md
+++ b/the-pid-controller/practical-improvements-to-pid.md
@@ -25,7 +25,7 @@ Each one of these methods has a relatively basic solution which we will analyze 
 
 Integral windup is a phenomenon that occurs whenever the integral output saturates our system.  Integral windup causes the system to remain traveling in the same direction for some time until the integral sum drops low enough for our system to regain control.  Brian Douglas does a fantastic job of explaining the issue of Integral windup on the Matlab youtube channel [here](https://youtu.be/NVLXCwc8HzM?t=201).  \
 \
-There are a few easy things that can be implemented to help reduce the likely hood of integral windup occuring.  One of these is to simply put limits on our Integral sum such as in the following code example:
+There are a few easy things that can be implemented to help reduce the likely hood of integral windup occurring.  One of these is to simply put limits on our Integral sum such as in the following code example:
 
 ```java
 // sum our integral


### PR DESCRIPTION
Found some spelling issues while reading this online.

Most are pretty straight forward - I changed `deacceleration` to `deceleration` but given its use as a variable the original spelling may be important in some way that I don't grok.  Happy to update the PR without those changes